### PR TITLE
Change path to the email templates

### DIFF
--- a/src/emails/index.js
+++ b/src/emails/index.js
@@ -4,51 +4,51 @@ const templateList = {
   [emailSubject.EMAIL_CONFIRMATION]: {
     en: {
       subject: 'Please confirm your email',
-      template: 'en/confirm-email'
+      template: `${__dirname}/en/confirm-email`
     },
     ua: {
       subject: 'Будь ласка, підтвердіть свою електронну адресу',
-      template: 'ua/confirm-email'
+      template: `${__dirname}/ua/confirm-email`
     }
   },
   [emailSubject.RESET_PASSWORD]: {
     en: {
       subject: 'Reset your account password',
-      template: 'en/reset-password'
+      template: `${__dirname}/en/reset-password`
     },
     ua: {
       subject: 'Скиньте пароль для свого акаунту',
-      template: 'ua/reset-password'
+      template: `${__dirname}/ua/reset-password`
     }
   },
   [emailSubject.SUCCESSFUL_PASSWORD_RESET]: {
     en: {
       subject: 'Your password was changed',
-      template: 'en/sucessful-password-reset'
+      template: `${__dirname}/en/sucessful-password-reset`
     },
     ua: {
       subject: 'Ваш пароль було змінено',
-      template: 'ua/sucessful-password-reset'
+      template: `${__dirname}/ua/sucessful-password-reset`
     }
   },
   [emailSubject.LONG_TIME_WITHOUT_LOGIN]: {
     en: {
       subject: 'You have been inactive for too long',
-      template: 'en/long-time-without-login'
+      template: `${__dirname}/en/long-time-without-login`
     },
     ua: {
       subject: 'Ви занадто довго були неактивні',
-      template: 'ua/long-time-without-login'
+      template: `${__dirname}/ua/long-time-without-login`
     }
   },
   [emailSubject.ADMIN_INVITATION]: {
     en: {
       subject: 'Admin invitation',
-      template: 'en/invite-admin'
+      template: `${__dirname}/en/invite-admin`
     },
     ua: {
       subject: 'Запрошення адміна',
-      template: 'ua/invite-admin'
+      template: `${__dirname}/ua/invite-admin`
     }
   }
 }


### PR DESCRIPTION
Previously, we had an error when creating a new user

Log
![image](https://github.com/Space2Study-UA-1156/BackEnd-01/assets/56509285/c5b58776-10c8-48ad-a898-3b61045ee8de)

Response
![image](https://github.com/Space2Study-UA-1156/BackEnd-01/assets/56509285/f17da19e-2907-49d3-8641-127d7c7a7579)

Client
![image](https://github.com/Space2Study-UA-1156/BackEnd-01/assets/56509285/10ea4979-ae66-4629-9159-f47f4ecf137e)

<hr />

### **After bug fixing**

Response
![image](https://github.com/Space2Study-UA-1156/BackEnd-01/assets/56509285/016190f6-c5c7-4bc8-9e31-362820fd0b56)

Client
![image](https://github.com/Space2Study-UA-1156/BackEnd-01/assets/56509285/dece0cf4-3887-4adc-93ee-7934fe800285)

Email
![image](https://github.com/Space2Study-UA-1156/BackEnd-01/assets/56509285/3c6bf032-4980-44f1-b44f-7cdaff599393)

![image](https://github.com/Space2Study-UA-1156/BackEnd-01/assets/56509285/1df4dd5c-ebe0-4d2d-9b4e-00062b3f0864)

DEMO

https://github.com/Space2Study-UA-1156/BackEnd-01/assets/56509285/faa76df7-4f34-4393-97bc-6bfc1ca97745


